### PR TITLE
Guard game start on script import

### DIFF
--- a/script/NLP-Hangman-Game.py
+++ b/script/NLP-Hangman-Game.py
@@ -198,9 +198,7 @@ def play_the_game(sentences):
     # Conclude the game with the final score.
     print(f"Congratulations! Your final score is {score}.")
 
-# Only start the interactive game when the script is executed directly.
 if __name__ == "__main__":
-    # Load the sentences from the gamedata files.
     sentences = connlu_scanner(directory_path)
     play_the_game(sentences)
 


### PR DESCRIPTION
ensure game only starts when `NLP-Hangman-Game.py` is run as a script
